### PR TITLE
Feature quay integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,27 @@ pip install -e homu
 
 homu
 ```
+
+### How to use admin interface
+
+Homu provides admin interface to add and auto-register repos in github and specified builder. Currently
+homu can only autoregister repo in Quay.io.
+
+To add repo to homu and register it within github & quay:
+
+```sh
+$ curl -XPUT -H"Authorization: {ADMUSER} {ADMTOKEN}" -H"Content-type: application/json" -d'{"owner": "{gh_owner}", "name": "{gh_repo}", "reviewers": ["{gh_reviewer}"], "github": {}, "builder": "quay", "quay": {"public": true}}' "http://{HOMU_IP}:{HOMU_PORT}/admin/repo"'
+{"quay": {"secret": "{secr}", "username": "{user}", "name": "{gh_repo}", "build_branches": ["master", "develop", "auto"], "ssh": {deploy_key_id}, "public": true, "url": "{quay_repo_url}", "webhooks": "{quay_webhook}"}, "owner": "{gh_owner}", "reviewers": ["{gh_reviewer}"], "builder": "quay", "name": "{gh_repo}", "github": {"secret": "{gh_secret}", "webhook_id": {gh_webhook_id}}, "label": "{repo_label}"}
+```
+
+This command will add repo to homu, store it to db for persistence, create hook on github, create repo
+on Quay.io, and register all necessary hooks there. One can add repos using other builders, but autoregistration is not supported for them.
+
+To delete repo and unregister it send DELETE request to `admind/repo/{repo_label}`. *WARNING*: this will remove repo in Quay.io:
+
+```sh
+$ curl -XDELETE -H"Authorization: {ADMUSER} {ADMTOKEN}" "http://{homu_ip}:{homu_port}/admin/repo/{repo_label}"
+{repo_label}
+```
+
+For builders other than Quay.io auto unregistration is not supported.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ $ curl -XPUT -H"Authorization: {ADMUSER} {ADMTOKEN}" -H"Content-type: applicatio
 This command will add repo to homu, store it to db for persistence, create hook on github, create repo
 on Quay.io, and register all necessary hooks there. One can add repos using other builders, but autoregistration is not supported for them.
 
-To delete repo and unregister it send DELETE request to `admind/repo/{repo_label}`. *WARNING*: this will remove repo in Quay.io:
+If you want to register existing quay repo in homu, add `"existing_repo"` key to `"quay"` settings and set it to name of your quay repo.
+
+To delete repo and unregister it send DELETE request to `admind/repo/{repo_label}`. To keep quay repo undeleted after unregistering, pass `?keep_repo=True`.
 
 ```sh
 $ curl -XDELETE -H"Authorization: {ADMUSER} {ADMTOKEN}" "http://{homu_ip}:{homu_port}/admin/repo/{repo_label}"

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -10,6 +10,13 @@ access_token = ""
 app_client_id = ""
 app_client_secret = ""
 
+# As we create webhooks automatically, we need to know our external address
+[external]
+hostname = "external IP"
+port = 80
+scheme = "https"
+
+
 [web]
 
 # The port homu listens on
@@ -19,6 +26,16 @@ port = 54856
 # The secret & username to call admin API
 secret = ''
 username = 'admin'
+
+[quay]
+# access token to use API
+access_token = ''
+# namespace to create repos in
+namespace = 'lhtest'
+# for some API methods we can't use access token, and we need to use username/pass
+# That's a shame
+username = ''
+password = ''
 
 # An example configuration for repository (there can be many of these)
 [repo.NAME]

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -15,6 +15,11 @@ app_client_secret = ""
 # The port homu listens on
 port = 54856
 
+[admin]
+# The secret & username to call admin API
+secret = ''
+username = 'admin'
+
 # An example configuration for repository (there can be many of these)
 [repo.NAME]
 

--- a/homu/main.py
+++ b/homu/main.py
@@ -299,6 +299,9 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db):
     elif 'travis' in repo_cfg:
         branch = repo_cfg.get('branch', {}).get('auto', 'auto')
         builders = ['travis']
+    elif 'quay' in repo_cfg:
+        branch = repo_cfg.get('branch', {}).get('auto', 'auto')
+        builders = ['quay']
     else:
         raise RuntimeError('Invalid configuration')
 
@@ -572,8 +575,12 @@ def main():
         if merge_sha:
             if 'buildbot' in repo_cfgs[repo_label]:
                 builders = repo_cfgs[repo_label]['buildbot']['builders']
-            else:
+            elif 'travis' in repo_cfgs[repo_label]:
                 builders = ['travis']
+            elif 'quay' in repo_cfgs[repo_label]:
+                builders = ['quay']
+            else:
+                RuntimeError('Invalid configuration!')
 
             state.init_build_res(builders, use_db=False)
             state.merge_sha = merge_sha

--- a/homu/main.py
+++ b/homu/main.py
@@ -311,6 +311,8 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db):
     elif 'quay' in repo_cfg:
         branch = repo_cfg.get('branch', {}).get('auto', 'auto')
         builders = ['quay']
+        # We do not notify quay here; we wait for push event from github instead
+        # this way we can be sure quay will be able to fetch merge commit
     else:
         raise RuntimeError('Invalid configuration')
 

--- a/homu/main.py
+++ b/homu/main.py
@@ -218,24 +218,26 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, *, realtime
             state.rollup = word == 'rollup'
 
         elif word == 'force' and realtime:
-            with buildbot_sess(repo_cfg) as sess:
-                res = sess.post(repo_cfg['buildbot']['url'] + '/builders/_selected/stopselected', allow_redirects=False, data={
-                    'selected': repo_cfg['buildbot']['builders'],
-                    'comments': INTERRUPTED_BY_HOMU_FMT.format(int(time.time())),
-                })
+            if 'buildbot' in repo_cfg:
+                with buildbot_sess(repo_cfg) as sess:
+                    res = sess.post(repo_cfg['buildbot']['url'] + '/builders/_selected/stopselected', allow_redirects=False, data={
+                        'selected': repo_cfg['buildbot']['builders'],
+                        'comments': INTERRUPTED_BY_HOMU_FMT.format(int(time.time())),
+                    })
 
-            if 'authzfail' in res.text:
-                err = 'Authorization failed'
-            else:
-                mat = re.search('(?s)<div class="error">(.*?)</div>', res.text)
-                if mat:
-                    err = mat.group(1).strip()
-                    if not err: err = 'Unknown error'
+                if 'authzfail' in res.text:
+                    err = 'Authorization failed'
                 else:
-                    err = ''
-
-            if err:
-                state.add_comment(':bomb: Buildbot returned an error: `{}`'.format(err))
+                    mat = re.search('(?s)<div class="error">(.*?)</div>', res.text)
+                    if mat:
+                        err = mat.group(1).strip()
+                        if not err: err = 'Unknown error'
+                    else:
+                        err = ''
+                if err:
+                    state.add_comment(':bomb: Buildbot returned an error: `{}`'.format(err))
+            else:
+                state.add_comment(':disappointed: "force" is only available for buildbot')
 
         elif word == 'clean' and realtime:
             state.merge_sha = ''

--- a/homu/main.py
+++ b/homu/main.py
@@ -540,13 +540,17 @@ def main():
     for repo_label, repo_cfg in cfg.get('repo', {}).items():
         # add key 'label' to be consistent with confs read from db
         repo_cfg['label'] = repo_label
+        # keep builder settings structure in sync with those loaded from db
+        # add `builder` key to use as dispatch elsewhere
+        # Use first found builder settings as builder kind
+        repo_cfg['builder'] = next(k for k in ['quay', 'travis', 'buildbot']
+                                   if k in repo_cfg)
         repo_cfgs[repo_label] = repo_cfg
 
     # b) load conf from db
     for repo_cfg in db_fetch_dicts(db, 'SELECT * from repo'):
         repo_label = repo_cfg['label']
-        # keep builder settings structure in sync with those loaded from cfg
-        builder_kind = repo_cfg.pop('builder')
+        builder_kind = repo_cfg['builder']
         repo_cfg[builder_kind] = json.loads(repo_cfg.pop('builder_settings'))
         # convert github/branches/reviewers from json:
         for key in ['github', 'branches', 'reviewers']:

--- a/homu/main.py
+++ b/homu/main.py
@@ -463,7 +463,7 @@ def fetch_mergeability(mergeable_que):
             mergeable_que.task_done()
 
 def arguments():
-    parser = argparse.ArgumentParser(description =
+    parser = argparse.ArgumentParser(description=
                                      'A bot that integrates with GitHub and '
                                      'your favorite continuous integration service')
     parser.add_argument('-v', '--verbose',

--- a/homu/main.py
+++ b/homu/main.py
@@ -659,7 +659,10 @@ def main():
             return process_queue(states, repos, repo_cfgs, logger, buildbot_slots, db)
 
     from . import server
-    Thread(target=server.start, args=[cfg, states, queue_handler, repo_cfgs, repos, logger, buildbot_slots, my_username, db, repo_labels, mergeable_que]).start()
+    Thread(target=server.start, args=[cfg, states, queue_handler,
+                                      repo_cfgs, repos, logger, buildbot_slots,
+                                      my_username, db, repo_labels,
+                                      mergeable_que, gh]).start()
 
     Thread(target=fetch_mergeability, args=[mergeable_que]).start()
 

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -84,7 +84,6 @@ class Quay:
             create_url = self.url('customtrigger/setup', namespace, repo)
             resp = sess.get(create_url, headers=self.auth_header)
             resp.raise_for_status()
-            # TODO: handle errors and re-raise?
             trigger_uuid = utils.get_query(resp.url)['newtrigger'][0]
             csrf_token = CSRF_TOKEN_RE.search(resp.text).groups()[0]
             activate_url = self.api_url('repository', namespace, repo,
@@ -93,8 +92,6 @@ class Quay:
             config = {'build_source': git_url, 'subdir':'/'}
             resp = sess.post(activate_url,
                              json={'config': config})
-            # TODO: remove trigger if not activated?
-            # DELETE https://quay.io/api/v1/repository/lhtest/apitest/trigger/b48bf16e-2559-4e4e-810c-826417cec9ee?_csrf_token=xzQ7yMOL6MEvL8Cv0%2FJtCignQnAwCNvl7P0Po5NOgYhRjFgnBgyeb0O6j3QBTVy%2F
             resp.raise_for_status()
             trigger = resp.json()
         result = {

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -118,7 +118,7 @@ class Quay:
         r.raise_for_status()
         return r.json()['uuid']
 
-
+# TODO: classmethods?
 def register(g, repo, settings):
     logger = g.logger
     q = Quay(g.cfg['quay'])

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -78,9 +78,9 @@ class QuayThing:
 
     def _create_child(self, kls, *args, **kwargs):
         params = utils.merge_dicts(self.basic_params,
-                                   self.inherited)
-        params = utils.merge_dicts(params, parent_url=self.thing_url)
-        params = utils.merge_dicts(params, kwargs)
+                                   self.inherited,
+                                   kwargs,
+                                   parent_url=self.thing_url)
         return kls(*args, **params)
 
     def _make_url(self, *paths, query=None):

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -1,10 +1,12 @@
 # API wrappers for quay
 import re
+import functools
 from contextlib import contextmanager
 
 import requests
 
 from . import utils
+from .utils import lazy_debug
 
 QUAY_SCHEME = 'https'
 QUAY_HOSTNAME = 'quay.io'
@@ -55,7 +57,6 @@ class Quay:
                               headers=self.auth_header,
                               json={})
 
-    # TODO: change defaults
     # TODO: object to represent repo?
     # TODO: only one namespace?
     def create_repo(self, name, private=True, namespace=None):
@@ -116,3 +117,49 @@ class Quay:
                                 'config': {'url': webhook_url}})
         r.raise_for_status()
         return r.json()['uuid']
+
+
+def register(g, repo, settings):
+    logger = g.logger
+    q = Quay(g.cfg['quay'])
+    lazy_debug(logger, lambda: 'Going to create quay repo: {}'.format(repo.name))
+    # private by default
+    private = settings.get('private', not settings.get('public', False))
+    repo_info = q.create_repo(repo.name, private=private)
+    settings.update(repo_info)
+    lazy_debug(logger, lambda: 'Quay repo created: {} '.format(repo_info))
+    q_name = repo_info['name']
+    lazy_debug(logger, lambda: 'Going to create build trigger for: {} in {}'.format(
+        repo.ssh_url, q_name))
+    q_build_trigger = q.create_build_trigger(q_name, repo.ssh_url)
+    lazy_debug(logger, lambda: 'Build trigger created in {}: {}'.format(
+        q_name, q_build_trigger['id']))
+    # Web hook to call to trigger build on push
+    settings['webhook'] = q_build_trigger['webhook']
+    lazy_debug(logger, lambda: 'Going to register deploy key in {}/{}'.format(
+        repo.owner, repo.name))
+    deploy_key = repo.create_key('Quay.io Builder', q_build_trigger['ssh'])
+    # Save the key id, so we can remove it later
+    settings['ssh'] = deploy_key.id
+    settings['secret'] = quay_secret = settings.get('secret',
+                                                    utils.random_string())
+    settings['username'] = quay_username = settings.get('username',
+                                                        utils.random_string())
+    quay_webhook = g.make_webhook_url('quay', quay_username, quay_secret)
+    lazy_debug(logger, lambda: 'Registering {} as status webhooks in {}'.format(
+        quay_webhook, q_name))
+    q.add_web_hook(q_name, EVENT_BUILD_SUCCESS, quay_webhook)
+    q.add_web_hook(q_name, EVENT_BUILD_FAILURE, quay_webhook)
+
+def unregister(g, repo, settings):
+    logger = g.logger
+    lazy_debug(logger, lambda: 'Going to remove quay repo: {}'.format(settings))
+    ignore = functools.partial(utils.ignore, logger=g.logger)
+    q = Quay(g.cfg['quay'])
+    lazy_debug(logger, lambda: 'Going to remove deploy key from: {}/{}'.format(
+        repo.owner, repo.name))
+    ignore(lambda: utils.maybe_call(settings, 'ssh', repo.delete_key))
+    # build trigger and webhooks will go away along with repo
+    lazy_debug(logger, lambda: 'Going to delete repo from quay: {}'.format(
+        settings))
+    ignore(lambda: utils.maybe_call(settings, 'name', q.delete_repo))

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -125,7 +125,7 @@ class Namespace(NamespacedThing):
 
 class Repo(NamespacedThing):
     def __init__(self, name, **kwargs):
-        super(self.__class__, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.details['name'] = name
         self.details['url'] = self._make_url('repository', self.namespace, name)
         self._set_thing_api_url(self._api_url(),
@@ -184,7 +184,7 @@ class Repo(NamespacedThing):
 
 class BuildTrigger(NamespacedThing):
     def __init__(self, uuid, ssh=None, webhook=None, **kwargs):
-        super(self.__class__, self).__init__(thing_path=['trigger', uuid],
+        super().__init__(thing_path=['trigger', uuid],
                                              **kwargs)
         self.details['uuid'] = uuid
         self.details['ssh'] = ssh
@@ -199,7 +199,7 @@ class BuildTrigger(NamespacedThing):
 
 class Hook(NamespacedThing):
     def __init__(self, uuid, **kwargs):
-        super(self.__class__, self).__init__(thing_path=['notification', uuid],
+        super().__init__(thing_path=['notification', uuid],
                                              **kwargs)
         self.details['uuid'] = uuid
 

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -1,0 +1,118 @@
+# API wrappers for quay
+import re
+from contextlib import contextmanager
+
+import requests
+
+from . import utils
+
+QUAY_SCHEME = 'https'
+QUAY_HOSTNAME = 'quay.io'
+QUAY_API = 'api/v1/'
+CSRF_TOKEN_RE = re.compile(r'__token\s?=\s?\'(.*)\';')
+
+EVENT_BUILD_SUCCESS = 'build_success'
+EVENT_BUILD_FAILURE = 'build_failure'
+
+# import http.client as http_client
+# http_client.HTTPConnection.debuglevel = 1
+
+class Quay:
+    def __init__(self, cfg):
+        self.access_token = cfg['access_token']
+        self.username = cfg['username']
+        self.password = cfg['password']
+        self.hostname = cfg.get('address', QUAY_HOSTNAME)
+        self.api_prefix = cfg.get('api_prefix', QUAY_API)
+        self.scheme = cfg.get('scheme', QUAY_SCHEME)
+        self.namespace = cfg['namespace']
+        # Quay.io has it own sense of http basic auth, so we can't use
+        # requests `auth` param. We need to send access_token *as is*,
+        # not the result of `hashfunc(username+token)`.
+        # So we craft auth header ourselves as "Bearer {access_token}"
+        self.auth_header = {'Authorization': 'Bearer {}'.format(
+            self.access_token)}
+
+    def url(self, *paths, query=None):
+        path = utils.join_paths(*paths)
+        return utils.make_url(self.scheme, self.hostname,
+                              path, query=query)
+    def api_url(self, *paths, query=None):
+        paths = (self.api_prefix, ) + paths
+        return self.url(*paths, query=query)
+
+    @contextmanager
+    def login(self):
+        session = requests.Session()
+        r = session.post(self.api_url('signin'),
+                              headers=self.auth_header,
+                              json={'username': self.username,
+                                    'password': self.password})
+        # TODO: cleanup this with custom error classes
+        r.raise_for_status()
+        yield session
+        r = session.post(self.api_url('signout'),
+                              headers=self.auth_header,
+                              json={})
+
+    # TODO: change defaults
+    # TODO: object to represent repo?
+    # TODO: only one namespace?
+    def create_repo(self, name, private=True, namespace=None):
+        namespace = namespace or self.namespace
+        r = requests.post(self.api_url('repository'),
+                          headers=self.auth_header,
+                          json={'namespace': namespace, 'repository': name,
+                                'visibility': 'private' if private else 'public',
+                                'description': ''})
+        r.raise_for_status()
+        info = r.json()
+        url = self.url('repository', info['namespace'], info['name'])
+        return {'url': url, 'name': info['name']}
+
+    def delete_repo(self, name, namespace=None):
+        namespace = namespace or self.namespace
+        r = requests.delete(self.api_url('repository', namespace, name),
+                            headers=self.auth_header)
+        r.raise_for_status()
+
+    def create_build_trigger(self, repo, git_url, namespace=None):
+        namespace = namespace or self.namespace
+        trigger = None
+        with self.login() as sess:
+            create_url = self.url('customtrigger/setup', namespace, repo)
+            resp = sess.get(create_url, headers=self.auth_header)
+            resp.raise_for_status()
+            # TODO: handle errors and re-raise?
+            trigger_uuid = utils.get_query(resp.url)['newtrigger'][0]
+            csrf_token = CSRF_TOKEN_RE.search(resp.text).groups()[0]
+            activate_url = self.api_url('repository', namespace, repo,
+                                        'trigger', trigger_uuid, 'activate',
+                                        query={'_csrf_token': csrf_token})
+            config = {'build_source': git_url, 'subdir':'/'}
+            resp = sess.post(activate_url,
+                             json={'config': config})
+            # TODO: remove trigger if not activated?
+            # DELETE https://quay.io/api/v1/repository/lhtest/apitest/trigger/b48bf16e-2559-4e4e-810c-826417cec9ee?_csrf_token=xzQ7yMOL6MEvL8Cv0%2FJtCignQnAwCNvl7P0Po5NOgYhRjFgnBgyeb0O6j3QBTVy%2F
+            resp.raise_for_status()
+            trigger = resp.json()
+        result = {
+            'id': trigger['id']
+        }
+        interesting_keys = ['ssh', 'webhook']
+        for cred in trigger['config']['credentials']:
+            for key in interesting_keys:
+                if key in cred['name'].lower():
+                    result[key] = cred['value']
+        return result
+
+    def add_web_hook(self, repo, event, webhook_url, namespace=None):
+        namespace = namespace or self.namespace
+        url = self.api_url('repository', namespace, repo, 'notification/')
+        r = requests.post(url,
+                          headers=self.auth_header,
+                          json={'method': 'webhook',
+                                'event': event,
+                                'config': {'url': webhook_url}})
+        r.raise_for_status()
+        return r.json()['uuid']

--- a/homu/quay1.py
+++ b/homu/quay1.py
@@ -19,123 +19,224 @@ EVENT_BUILD_FAILURE = 'build_failure'
 # import http.client as http_client
 # http_client.HTTPConnection.debuglevel = 1
 
-class Quay:
-    def __init__(self, cfg):
-        self.access_token = cfg['access_token']
-        self.username = cfg['username']
-        self.password = cfg['password']
-        self.hostname = cfg.get('address', QUAY_HOSTNAME)
-        self.api_prefix = cfg.get('api_prefix', QUAY_API)
-        self.scheme = cfg.get('scheme', QUAY_SCHEME)
-        self.namespace = cfg['namespace']
+class QuayThing:
+    def __init__(self, access_token, username, password,
+                 address=QUAY_HOSTNAME, api_prefix=QUAY_API, scheme=QUAY_SCHEME,
+                 parent_url=None, thing_path=[]):
+        self.auth_credentials = {'username': username, 'password':password}
         # Quay.io has it own sense of http basic auth, so we can't use
         # requests `auth` param. We need to send access_token *as is*,
         # not the result of `hashfunc(username+token)`.
         # So we craft auth header ourselves as "Bearer {access_token}"
         self.auth_header = {'Authorization': 'Bearer {}'.format(
-            self.access_token)}
+            access_token)}
+        self.scheme = scheme
+        self.access_token = access_token
+        self.api_prefix = api_prefix
+        self.address = address
+        self._set_thing_api_url(parent_url, *thing_path)
+        self.basic_params = dict(access_token=access_token,
+                                 username=username,
+                                 password=password,
+                                 scheme=scheme,
+                                 api_prefix=api_prefix,
+                                 address=address)
+        # Parameter, that need to be passed to childs
+        self.inherited = {}
+        # Other parameters that need to be stored
+        self.details = {}
 
-    def url(self, *paths, query=None):
+    def __repr__(self):
+        return '{}: {}'.format(super().__repr__(), self.as_dict())
+
+    # Convinient access to inherited/details
+    def __getattr__(self, name):
+        val = self.inherited.get(name, self.details.get(name))
+        if val is None:
+            raise AttributeError(name)
+        else:
+            return val
+
+    def as_dict(self):
+        return utils.merge_dicts(self.inherited, self.details)
+
+    def delete(self):
+        if self.thing_url is not None:
+            r = requests.delete(self.thing_url,
+                                headers=self.auth_header)
+            r.raise_for_status()
+        else:
+            raise TypeError('Object does not support deletion')
+
+    def refresh(self):
+        if self.thing_url is not None and hasattr(self, 'update_details'):
+            r = requests.get(self.thing_url, headers=self.auth_header)
+            r.raise_for_status()
+            self.update_details(r.json())
+        else:
+            raise TypeError('Object does not support refreshing')
+
+    def _create_child(self, kls, *args, **kwargs):
+        params = utils.merge_dicts(self.basic_params,
+                                   self.inherited)
+        params = utils.merge_dicts(params, parent_url=self.thing_url)
+        params = utils.merge_dicts(params, kwargs)
+        return kls(*args, **params)
+
+    def _make_url(self, *paths, query=None):
         path = utils.join_paths(*paths)
-        return utils.make_url(self.scheme, self.hostname,
+        return utils.make_url(self.scheme, self.address,
                               path, query=query)
-    def api_url(self, *paths, query=None):
+    def _api_url(self, *paths, query=None):
         paths = (self.api_prefix, ) + paths
-        return self.url(*paths, query=query)
+        return self._make_url(*paths, query=query)
+    def _child_api_url(self, *paths, **query_params):
+        if self.thing_url is not None:
+            return utils.add_url_params(utils.join_url(self.thing_url, *paths),
+                                        **query_params)
+        else:
+            raise TypeError('Thing can not have child entities')
+    def _set_thing_api_url(self, parent_url=None, *paths):
+        if parent_url:
+            self.thing_url = utils.join_url(parent_url, *paths)
+        else:
+            self.thing_url = None
 
-    @contextmanager
-    def login(self):
-        session = requests.Session()
-        r = session.post(self.api_url('signin'),
-                              headers=self.auth_header,
-                              json={'username': self.username,
-                                    'password': self.password})
-        # TODO: cleanup this with custom error classes
-        r.raise_for_status()
-        yield session
-        r = session.post(self.api_url('signout'),
-                              headers=self.auth_header,
-                              json={})
+class NamespacedThing(QuayThing):
+    def __init__(self, namespace=None, **kwargs):
+        super().__init__(**kwargs)
+        self.inherited['namespace'] = namespace
 
-    # TODO: object to represent repo?
-    # TODO: only one namespace?
-    def create_repo(self, name, private=True, namespace=None):
-        namespace = namespace or self.namespace
-        r = requests.post(self.api_url('repository'),
+class Namespace(NamespacedThing):
+    # TODO: save private?
+    def create_repo(self, name, private=True):
+        r = requests.post(self._api_url('repository'),
                           headers=self.auth_header,
-                          json={'namespace': namespace, 'repository': name,
+                          json={'namespace': self.namespace, 'repository': name,
                                 'visibility': 'private' if private else 'public',
                                 'description': ''})
         r.raise_for_status()
         info = r.json()
-        url = self.url('repository', info['namespace'], info['name'])
-        return {'url': url, 'name': info['name']}
+        return self.repo(info['name'])
 
-    def delete_repo(self, name, namespace=None):
-        namespace = namespace or self.namespace
-        r = requests.delete(self.api_url('repository', namespace, name),
-                            headers=self.auth_header)
+    # Get the repo object (NOTE: no requests are made here)
+    def repo(self, name):
+        return self._create_child(Repo, name)
+
+class Repo(NamespacedThing):
+    def __init__(self, name, **kwargs):
+        super(self.__class__, self).__init__(**kwargs)
+        self.details['name'] = name
+        self.details['url'] = self._make_url('repository', self.namespace, name)
+        self._set_thing_api_url(self._api_url(),
+                                'repository', self.namespace, name)
+
+    @contextmanager
+    def login(self):
+        session = requests.Session()
+        r = session.post(self._api_url('signin'),
+                         headers=self.auth_header,
+                         json=self.auth_credentials)
+        # TODO: cleanup this with custom error classes
         r.raise_for_status()
+        yield session
+        r = session.post(self._api_url('signout'),
+                         headers=self.auth_header,
+                         json={})
 
-    def create_build_trigger(self, repo, git_url, namespace=None):
-        namespace = namespace or self.namespace
-        trigger = None
+    # much rest very api
+    def create_build_trigger(self, git_url):
         with self.login() as sess:
-            create_url = self.url('customtrigger/setup', namespace, repo)
+            create_url = self._make_url('customtrigger/setup',
+                                       self.namespace, self.name)
             resp = sess.get(create_url, headers=self.auth_header)
             resp.raise_for_status()
             trigger_uuid = utils.get_query(resp.url)['newtrigger'][0]
             csrf_token = CSRF_TOKEN_RE.search(resp.text).groups()[0]
-            activate_url = self.api_url('repository', namespace, repo,
-                                        'trigger', trigger_uuid, 'activate',
-                                        query={'_csrf_token': csrf_token})
+            # XXX: Ideally, we want to run this in BuildTrigger itself
+            activate_url = self._child_api_url('trigger', trigger_uuid,
+                                               'activate',
+                                               _csrf_token=csrf_token)
             config = {'build_source': git_url, 'subdir':'/'}
             resp = sess.post(activate_url,
                              json={'config': config})
             resp.raise_for_status()
-            trigger = resp.json()
-        result = {
-            'id': trigger['id']
-        }
-        interesting_keys = ['ssh', 'webhook']
-        for cred in trigger['config']['credentials']:
-            for key in interesting_keys:
-                if key in cred['name'].lower():
-                    result[key] = cred['value']
-        return result
+            trigger_json = resp.json()
+        trigger = self.build_trigger(trigger_json['id'])
+        trigger.update_details(trigger_json)
+        return trigger
 
-    def add_web_hook(self, repo, event, webhook_url, namespace=None):
-        namespace = namespace or self.namespace
-        url = self.api_url('repository', namespace, repo, 'notification/')
-        r = requests.post(url,
+    # Get the build_trigger object (NOTE: no requests are made here)
+    def build_trigger(self, uuid):
+        return self._create_child(BuildTrigger, uuid)
+
+    def create_web_hook(self, event, webhook_url):
+        r = requests.post(self._child_api_url('notification/'),
                           headers=self.auth_header,
                           json={'method': 'webhook',
                                 'event': event,
                                 'config': {'url': webhook_url}})
         r.raise_for_status()
-        return r.json()['uuid']
+        return self.web_hook(r.json()['uuid'])
 
-# TODO: classmethods?
+    def web_hook(self, uuid):
+        return self._create_child(Hook, uuid)
+
+class BuildTrigger(NamespacedThing):
+    def __init__(self, uuid, ssh=None, webhook=None, **kwargs):
+        super(self.__class__, self).__init__(thing_path=['trigger', uuid],
+                                             **kwargs)
+        self.details['uuid'] = uuid
+        self.details['ssh'] = ssh
+        self.details['webhook'] = webhook
+
+    def update_details(self, thing_json):
+        interesting_keys = ['ssh', 'webhook']
+        for cred in thing_json['config']['credentials']:
+            for key in interesting_keys:
+                if key in cred['name'].lower():
+                    self.details[key] = cred['value']
+
+class Hook(NamespacedThing):
+    def __init__(self, uuid, **kwargs):
+        super(self.__class__, self).__init__(thing_path=['notification', uuid],
+                                             **kwargs)
+        self.details['uuid'] = uuid
+
+
 def register(g, repo, settings):
     logger = g.logger
-    q = Quay(g.cfg['quay'])
-    lazy_debug(logger, lambda: 'Going to create quay repo: {}'.format(repo.name))
-    # private by default
-    private = settings.get('private', not settings.get('public', False))
-    repo_info = q.create_repo(repo.name, private=private)
-    settings.update(repo_info)
-    lazy_debug(logger, lambda: 'Quay repo created: {} '.format(repo_info))
-    q_name = repo_info['name']
-    lazy_debug(logger, lambda: 'Going to create build trigger for: {} in {}'.format(
-        repo.ssh_url, q_name))
-    q_build_trigger = q.create_build_trigger(q_name, repo.ssh_url)
+    namespace = Namespace(**g.cfg['quay'])
+    existing_repo = settings.get('existing_repo')
+    # We're keeping existing_repo flag, so we will not delete repo in rollback
+    # if smth will go wrong during registration process
+    if existing_repo is not None:
+        lazy_debug(logger, lambda: 'Going to use existing repo: {}'.format(
+            existing_repo))
+        # Do not create repo, if we want to use extisting
+        quay_repo = namespace.repo(existing_repo)
+    else:
+        lazy_debug(logger, lambda: 'Going to create quay repo: {}'.format(repo.name))
+        # private by default
+        private = settings.get('private', not settings.get('public', False))
+        quay_repo = namespace.create_repo(repo.name, private=private)
+    settings.update(quay_repo.as_dict())
+    lazy_debug(logger, lambda: 'Got quay repo: {} '.format(quay_repo))
+    lazy_debug(logger,
+               lambda: 'Going to create build trigger for: {} in {}'.format(
+                   repo.ssh_url, quay_repo.name))
+    build_trigger = quay_repo.create_build_trigger(repo.ssh_url)
     lazy_debug(logger, lambda: 'Build trigger created in {}: {}'.format(
-        q_name, q_build_trigger['id']))
+        quay_repo.name, build_trigger.uuid))
+    # We can't just store quay repo id and request triggers/webhooks later
+    # Because there might be another webhooks / triggers we don't want to delete
     # Web hook to call to trigger build on push
-    settings['webhook'] = q_build_trigger['webhook']
+    settings['webhook'] = build_trigger.webhook
+    # Save build trigger id, so we can remove it
+    settings['trigger_uuid'] = build_trigger.uuid
     lazy_debug(logger, lambda: 'Going to register deploy key in {}/{}'.format(
         repo.owner, repo.name))
-    deploy_key = repo.create_key('Quay.io Builder', q_build_trigger['ssh'])
+    deploy_key = repo.create_key('Quay.io Builder', build_trigger.ssh)
     # Save the key id, so we can remove it later
     settings['ssh'] = deploy_key.id
     settings['secret'] = quay_secret = settings.get('secret',
@@ -144,22 +245,50 @@ def register(g, repo, settings):
                                                         utils.random_string())
     quay_webhook = g.make_webhook_url('quay', quay_username, quay_secret)
     lazy_debug(logger, lambda: 'Registering {} as status webhooks in {}'.format(
-        quay_webhook, q_name))
-    q.add_web_hook(q_name, EVENT_BUILD_SUCCESS, quay_webhook)
-    q.add_web_hook(q_name, EVENT_BUILD_FAILURE, quay_webhook)
+        quay_webhook, quay_repo.name))
+    settings['status_webhook_uuids'] = [
+        quay_repo.create_web_hook(EVENT_BUILD_SUCCESS, quay_webhook).uuid,
+        quay_repo.create_web_hook(EVENT_BUILD_FAILURE, quay_webhook).uuid
+    ]
+    # Remove existing_repo flag, so decision on removing repo will be done
+    # solely on keep_repo flag
+    settings.pop('existing_repo', None)
 
 def unregister(g, repo, settings):
     logger = g.logger
-    lazy_debug(logger, lambda: 'Going to remove quay repo: {}'.format(settings))
     ignore = functools.partial(utils.ignore, logger=g.logger)
-    q = Quay(g.cfg['quay'])
+    namespace = Namespace(**g.cfg['quay'])
+    lazy_debug(logger, lambda: 'Going to unregister quay repo: {}'.format(
+        settings))
+    quay_repo = utils.maybe_call(settings, 'name', namespace.repo)
+    # Do not have 'name' in settings, maybe haven't created it
+    if quay_repo is None:
+        return
+    if 'existing_repo' in settings or 'keep_repo' in settings:
+        # We do not want to delete quay repo,
+        # So we need to delete build trigger and hooks
+        lazy_debug(logger,
+                   lambda: 'Going to delete build trigger from quay: {}'.format(
+                       settings.get('trigger_uuid')))
+        ignore(lambda:
+               utils.maybe_call(settings, 'trigger_uuid',
+                                lambda t: quay_repo.build_trigger(t).delete()))
+        lazy_debug(logger,
+                   lambda: 'Going to delete web hooks from quay: {}'.format(
+                       settings.get('status_webhook_uuids')))
+        ignore(lambda:
+               utils.maybe_call(settings, 'status_webhook_uuids',
+                                lambda ids:
+                                [quay_repo.web_hook(h).delete() for h in ids]))
+    else:
+        # build trigger and webhooks will go away along with repo
+        lazy_debug(logger, lambda: 'Going to delete repo from quay: {}'.format(
+            settings.get('name')))
+        ignore(lambda: quay_repo.delete())
     lazy_debug(logger, lambda: 'Going to remove deploy key from: {}/{}'.format(
         repo.owner, repo.name))
     ignore(lambda: utils.maybe_call(settings, 'ssh', repo.delete_key))
-    # build trigger and webhooks will go away along with repo
-    lazy_debug(logger, lambda: 'Going to delete repo from quay: {}'.format(
-        settings))
-    ignore(lambda: utils.maybe_call(settings, 'name', q.delete_repo))
+
 
 def push_hook(g, push_event, settings):
     ref = push_event['ref'][len('refs/heads/'):]

--- a/homu/server.py
+++ b/homu/server.py
@@ -766,7 +766,7 @@ def admin_delete_repo(repo_label):
         # TODO: maybe cancel build and all that?
         unregister_and_forget(repo_label)
         db_query(g.db, 'DELETE from repo where label = ?', [repo_label])
-        lazy_debug(logger, lambda: 'Repo deleted and unregistered: {}'.format(
+        lazy_debug(g.logger, lambda: 'Repo deleted and unregistered: {}'.format(
             repo_label))
         return repo_label
     else:

--- a/homu/server.py
+++ b/homu/server.py
@@ -545,4 +545,6 @@ def start(cfg, states, queue_handler, repo_cfgs, repos, logger, buildbot_slots, 
     g.repo_labels = repo_labels
     g.mergeable_que = mergeable_que
 
-    run(host='', port=cfg['web']['port'], server='waitress')
+    run(host=cfg['web'].get('host', ''),
+        port=cfg['web']['port'],
+        server='waitress')

--- a/homu/server.py
+++ b/homu/server.py
@@ -691,6 +691,7 @@ def admin_add_repo():
     github['webhook_id'] = h.id
     # Register in builder
     try:
+        # TODO: register for existing repo?
         register_in_buider(repo_label)
         lazy_debug(logger, lambda: 'Registered {} in builder {}: {}'.format(
             repo_label, repo_cfg['builder'], builder_settings))
@@ -724,6 +725,7 @@ def admin_add_repo():
 @delete('/admin/repo/<repo_label:path>')
 @check_admin_requirements()
 def admin_delete_repo(repo_label):
+    # TODO: unregister without removing a repo?
     response.content_type = 'text/plain'
     if repo_label in g.repo_cfgs:
         # TODO: maybe cancel build and all that?

--- a/homu/server.py
+++ b/homu/server.py
@@ -635,9 +635,6 @@ def check_admin_requirements(json=False):
         return wrapper
     return decorator
 
-# TODO: move and rename
-# TODO: Create context manager
-
 
 
 @put('/admin/repo')

--- a/homu/server.py
+++ b/homu/server.py
@@ -743,7 +743,7 @@ def admin_delete_repo(repo_label):
 @check_admin_requirements()
 def admin_ger_repo(repo_label):
     if repo_label in g.repo_cfgs:
-        return utils.merge_dicts(g.repo_cfgs[repo_label], {'label': repo_label})
+        return utils.merge_dicts(g.repo_cfgs[repo_label], label=repo_label)
     else:
         abort(404, repo_label)
 

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -5,6 +5,8 @@ import logging
 import binascii
 import posixpath
 
+from itertools import chain
+
 import github3
 
 def github_set_ref(repo, ref, sha, *, force=False, auto_create=True):
@@ -70,11 +72,14 @@ def update_in(dkt, key, func):
         dkt[key] = func(dkt[key])
     return dkt
 
-def merge_dicts(fst, snd=None, **kwargs):
-    snd = snd or kwargs
-    res = dict(fst)
-    res.update(snd)
-    return res
+# Merges dicts and kwargs passed:
+# d1 = {'x': 1}
+# d2 = {'y': 2}
+# merge_dicts(d1, d2, k1=3, k2=4)
+# {'x': 1, 'y': 2, 'k1': 3, 'k2': 4}
+def merge_dicts(*args, **kwargs):
+    return dict(chain(chain(*(d.items() for d in args)),
+                      kwargs.items()))
 
 def random_string(n=20):
     return binascii.b2a_hex(os.urandom(n)).decode()

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -46,3 +46,8 @@ def remove_url_keys_from_json(json):
 def lazy_debug(logger, f):
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f())
+
+def update_in(dkt, key, func):
+    if key in dkt:
+        dkt[key] = func(dkt[key])
+    return dkt

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -1,12 +1,18 @@
+import os
 import json
-import github3
+import urllib
 import logging
+import binascii
+import posixpath
+
+import github3
 
 def github_set_ref(repo, ref, sha, *, force=False, auto_create=True):
     url = repo._build_url('git', 'refs', ref, base_url=repo._api)
     data = {'sha': sha, 'force': force}
 
-    try: js = repo._json(repo._patch(url, data=json.dumps(data)), 200)
+    try:
+        js = repo._json(repo._patch(url, data=json.dumps(data)), 200)
     except github3.models.GitHubError as e:
         if e.code == 422 and auto_create:
             return repo.create_ref('refs/' + ref, sha)

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -51,3 +51,8 @@ def update_in(dkt, key, func):
     if key in dkt:
         dkt[key] = func(dkt[key])
     return dkt
+
+def merge_dicts(fst, snd):
+    res = dict(fst)
+    res.update(snd)
+    return res

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -113,6 +113,19 @@ def join_paths(*paths):
     # with different separator. So explicitly call posixpath.join
     return posixpath.join(*paths)
 
+def join_url(base_url, *paths):
+    path = join_paths(*paths)
+    if path.startswith('/'):
+        path = path[1:]
+    if not base_url.endswith('/'):
+        base_url = base_url + '/'
+    return urllib.parse.urljoin(base_url, path)
+
+def add_url_params(url, **query_params):
+    query = urllib.parse.urlencode(query_params)
+    (scheme, host, path, _, _) = urllib.parse.urlsplit(url)
+    return urllib.parse.urlunsplit((scheme, host, path, query, ''))
+
 def get_query(url):
     return urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
 

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -133,9 +133,3 @@ def add_url_params(url, **query_params):
 
 def get_query(url):
     return urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
-
-def webhook_url(cfg, path, username=None, password=None):
-    return make_url(**merge_dicts(cfg['external'],
-                                  path=path,
-                                  username=username,
-                                  password=password))

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -57,6 +57,14 @@ def maybe_call(dkt, key, func):
     if key in dkt:
         return func(dkt[key])
 
+# this thing could be a macros in the better world
+def ignore(func, error=Exception, logger=None):
+    try:
+        return func()
+    except error as e:
+        if logger:
+            logger.warning(e)
+
 def update_in(dkt, key, func):
     if key in dkt:
         dkt[key] = func(dkt[key])


### PR DESCRIPTION
### How to use admin interface

Homu provides admin interface to add and auto-register repos in github and specified builder. Currently
homu can only autoregister repo in Quay.io.

To add repo to homu and register it within github & quay:

``` sh
$ curl -XPUT -H"Authorization: {ADMUSER} {ADMTOKEN}" -H"Content-type: application/json" -d'{"owner": "{gh_owner}", "name": "{gh_repo}", "reviewers": ["{gh_reviewer}"], "github": {}, "builder": "quay", "quay": {"public": true}}' "http://{HOMU_IP}:{HOMU_PORT}/admin/repo"'
{"quay": {"secret": "{secr}", "username": "{user}", "name": "{gh_repo}", "build_branches": ["master", "develop", "auto"], "ssh": {deploy_key_id}, "public": true, "url": "{quay_repo_url}", "webhooks": "{quay_webhook}"}, "owner": "{gh_owner}", "reviewers": ["{gh_reviewer}"], "builder": "quay", "name": "{gh_repo}", "github": {"secret": "{gh_secret}", "webhook_id": {gh_webhook_id}}, "label": "{repo_label}"}
```

This command will add repo to homu, store it to db for persistence, create hook on github, create repo
on Quay.io, and register all necessary hooks there. One can add repos using other builders, but autoregistration is not supported for them.

If you want to register existing quay repo in homu, add `"existing_repo"` key to `"quay"` settings and set it to name of your quay repo.

To delete repo and unregister it send DELETE request to `admind/repo/{repo_label}`. To keep quay repo undeleted after unregistering, pass `?keep_repo=True`.

``` sh
$ curl -XDELETE -H"Authorization: {ADMUSER} {ADMTOKEN}" "http://{homu_ip}:{homu_port}/admin/repo/{repo_label}"
{repo_label}
```

For builders other than Quay.io auto unregistration is not supported.
